### PR TITLE
Add offline player cache logic

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -12,6 +12,16 @@
       <option name="url" value="https://oss.sonatype.org/content/groups/public/" />
     </remote-repository>
     <remote-repository>
+      <option name="id" value="spigot-repo" />
+      <option name="name" value="spigot-repo" />
+      <option name="url" value="https://hub.spigotmc.org/nexus/content/repositories/snapshots/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="shopkeepers-repo" />
+      <option name="name" value="shopkeepers-repo" />
+      <option name="url" value="https://repo.projectshard.dev/repository/releases/" />
+    </remote-repository>
+    <remote-repository>
       <option name="id" value="spigotmc-repo" />
       <option name="name" value="spigotmc-repo" />
       <option name="url" value="https://hub.spigotmc.org/nexus/content/repositories/snapshots/" />
@@ -30,6 +40,11 @@
       <option name="id" value="jboss.community" />
       <option name="name" value="JBoss Community repository" />
       <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="papermc" />
+      <option name="name" value="papermc" />
+      <option name="url" value="https://repo.papermc.io/repository/maven-public/" />
     </remote-repository>
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
     <list size="1">
@@ -12,7 +13,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="temurin-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
     <repositories>
         <repository>
-            <id>spigotmc-repo</id>
+            <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
@@ -63,7 +63,7 @@
         </repository>
         <repository>
             <id>shopkeepers-repo</id>
-            <url>https://nexus.lichtspiele.org/repository/releases/</url>
+            <url>https://repo.projectshard.dev/repository/releases/</url>
         </repository>
     </repositories>
 
@@ -71,13 +71,13 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20.1-R0.1-SNAPSHOT</version>
+            <version>1.21.3-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.nisovin.shopkeepers</groupId>
             <artifactId>ShopkeepersAPI</artifactId>
-            <version>2.17.1</version>
+            <version>2.23.3</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/nl/me/shopkeeperslist/cache/OfflinePlayerCache.java
+++ b/src/main/java/nl/me/shopkeeperslist/cache/OfflinePlayerCache.java
@@ -33,9 +33,4 @@ public class OfflinePlayerCache {
         // If a player cant be found in cache request single player
         return Bukkit.getOfflinePlayer(name);
     }
-
-    public static OfflinePlayer getOfflinePlayerByUUID(UUID uuid) {
-        // If UUID is used there will be no API requests
-        return Bukkit.getOfflinePlayer(uuid);
-    }
 }

--- a/src/main/java/nl/me/shopkeeperslist/cache/OfflinePlayerCache.java
+++ b/src/main/java/nl/me/shopkeeperslist/cache/OfflinePlayerCache.java
@@ -1,0 +1,53 @@
+package nl.me.shopkeeperslist.cache;
+
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+
+import java.util.Objects;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+public class OfflinePlayerCache {
+
+    private static final Logger log = Logger.getLogger("OfflinePlayerCache");
+
+    private static OfflinePlayer[] offlinePlayers;
+    private static long expirationTimeMillis;
+
+    private static OfflinePlayer[] getOfflinePlayers() {
+        if (offlinePlayers == null || expirationTimeMillis < System.currentTimeMillis()) {
+            offlinePlayers = Bukkit.getOfflinePlayers();
+
+            // Set cache time of 10 minutes
+            expirationTimeMillis = System.currentTimeMillis() + (600 * 1000);
+        }
+
+        return offlinePlayers;
+    }
+
+    public static OfflinePlayer getOfflinePlayer(String name) {
+        OfflinePlayer[] offlinePlayers = getOfflinePlayers();
+
+        for (OfflinePlayer offlinePlayer : offlinePlayers) {
+            if (Objects.requireNonNull(offlinePlayer.getName()).equalsIgnoreCase(name)) {
+                return offlinePlayer;
+            }
+        }
+
+        // If a player cant be found in cache request single player
+        return Bukkit.getOfflinePlayer(name);
+    }
+
+    public static OfflinePlayer getOfflinePlayerByUUID(UUID uuid) {
+        OfflinePlayer[] offlinePlayers = getOfflinePlayers();
+
+        for (OfflinePlayer offlinePlayer : offlinePlayers) {
+            if (Objects.requireNonNull(offlinePlayer.getUniqueId()).equals(uuid)) {
+                return offlinePlayer;
+            }
+        }
+
+        // If a player cant be found in cache request single player
+        return Bukkit.getOfflinePlayer(uuid);
+    }
+}

--- a/src/main/java/nl/me/shopkeeperslist/cache/OfflinePlayerCache.java
+++ b/src/main/java/nl/me/shopkeeperslist/cache/OfflinePlayerCache.java
@@ -5,12 +5,8 @@ import org.bukkit.OfflinePlayer;
 
 import java.util.Objects;
 import java.util.UUID;
-import java.util.logging.Logger;
 
 public class OfflinePlayerCache {
-
-    private static final Logger log = Logger.getLogger("OfflinePlayerCache");
-
     private static OfflinePlayer[] offlinePlayers;
     private static long expirationTimeMillis;
 
@@ -39,15 +35,7 @@ public class OfflinePlayerCache {
     }
 
     public static OfflinePlayer getOfflinePlayerByUUID(UUID uuid) {
-        OfflinePlayer[] offlinePlayers = getOfflinePlayers();
-
-        for (OfflinePlayer offlinePlayer : offlinePlayers) {
-            if (Objects.requireNonNull(offlinePlayer.getUniqueId()).equals(uuid)) {
-                return offlinePlayer;
-            }
-        }
-
-        // If a player cant be found in cache request single player
+        // If UUID is used there will be no API requests
         return Bukkit.getOfflinePlayer(uuid);
     }
 }

--- a/src/main/java/nl/me/shopkeeperslist/utils/ShopDisplayUtils.java
+++ b/src/main/java/nl/me/shopkeeperslist/utils/ShopDisplayUtils.java
@@ -4,7 +4,6 @@ import com.nisovin.shopkeepers.api.shopkeeper.ShopType;
 import com.nisovin.shopkeepers.api.shopkeeper.Shopkeeper;
 import com.nisovin.shopkeepers.api.shopkeeper.TradingRecipe;
 import com.nisovin.shopkeepers.api.util.UnmodifiableItemStack;
-import nl.me.shopkeeperslist.cache.OfflinePlayerCache;
 import nl.me.shopkeeperslist.enums.ShopGUIType;
 import nl.me.shopkeeperslist.inventoryHolders.ShopInventoryHolder;
 import nl.me.shopkeeperslist.ShopkeepersList;
@@ -175,7 +174,7 @@ public class ShopDisplayUtils {
     public static ItemStack getHeadItem(Shopkeeper shopkeeper) {
         UUID uuid = ShopFindingUtils.findShopOwnerUUID(shopkeeper);
         if (uuid == null) return new ItemStack(Material.PLAYER_HEAD, 1);
-        OfflinePlayer offlinePlayer = OfflinePlayerCache.getOfflinePlayerByUUID(uuid);
+        OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(uuid);
         ItemStack headItem = new ItemStack(Material.PLAYER_HEAD, 1);
         SkullMeta skullMeta = (SkullMeta) headItem.getItemMeta();
         if (offlinePlayer.hasPlayedBefore()) skullMeta.setOwningPlayer(offlinePlayer);

--- a/src/main/java/nl/me/shopkeeperslist/utils/ShopDisplayUtils.java
+++ b/src/main/java/nl/me/shopkeeperslist/utils/ShopDisplayUtils.java
@@ -4,6 +4,7 @@ import com.nisovin.shopkeepers.api.shopkeeper.ShopType;
 import com.nisovin.shopkeepers.api.shopkeeper.Shopkeeper;
 import com.nisovin.shopkeepers.api.shopkeeper.TradingRecipe;
 import com.nisovin.shopkeepers.api.util.UnmodifiableItemStack;
+import nl.me.shopkeeperslist.cache.OfflinePlayerCache;
 import nl.me.shopkeeperslist.enums.ShopGUIType;
 import nl.me.shopkeeperslist.inventoryHolders.ShopInventoryHolder;
 import nl.me.shopkeeperslist.ShopkeepersList;
@@ -174,7 +175,7 @@ public class ShopDisplayUtils {
     public static ItemStack getHeadItem(Shopkeeper shopkeeper) {
         UUID uuid = ShopFindingUtils.findShopOwnerUUID(shopkeeper);
         if (uuid == null) return new ItemStack(Material.PLAYER_HEAD, 1);
-        OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(uuid);
+        OfflinePlayer offlinePlayer = OfflinePlayerCache.getOfflinePlayerByUUID(uuid);
         ItemStack headItem = new ItemStack(Material.PLAYER_HEAD, 1);
         SkullMeta skullMeta = (SkullMeta) headItem.getItemMeta();
         if (offlinePlayer.hasPlayedBefore()) skullMeta.setOwningPlayer(offlinePlayer);

--- a/src/main/java/nl/me/shopkeeperslist/utils/ShopFindingUtils.java
+++ b/src/main/java/nl/me/shopkeeperslist/utils/ShopFindingUtils.java
@@ -5,6 +5,7 @@ import com.nisovin.shopkeepers.api.shopkeeper.Shopkeeper;
 import com.nisovin.shopkeepers.api.shopkeeper.admin.AdminShopkeeper;
 import com.nisovin.shopkeepers.api.shopkeeper.player.PlayerShopkeeper;
 import com.nisovin.shopkeepers.api.util.UnmodifiableItemStack;
+import nl.me.shopkeeperslist.cache.OfflinePlayerCache;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.enchantments.Enchantment;
@@ -67,7 +68,7 @@ public class ShopFindingUtils {
      */
     public static List<Shopkeeper> findShopsForPlayer(String player) {
         List<Shopkeeper> shops = new ArrayList<>();
-        OfflinePlayer playerObj = Bukkit.getOfflinePlayer(player);
+        OfflinePlayer playerObj = OfflinePlayerCache.getOfflinePlayer(player);
         if (playerObj == null || !playerObj.hasPlayedBefore()) return shops;
         ShopkeepersAPI.getShopkeeperRegistry().getPlayerShopkeepersByOwner(playerObj.getUniqueId()).forEach(shopkeeper -> {
             shops.add(shopkeeper);


### PR DESCRIPTION
This cache was required because the requests for offline players would give an error if the command was used to many times in a short while. This is caused by the amount of shopkeepers we have on the server and different shop owners. This pull request is a overall optimalization of the plugin. Below is the stacktrace which would be shown whenever the API limit had been reached.

Problem being caused by: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/Bukkit.html#getOfflinePlayer(java.lang.String)

`[19:19:09] [Profile Lookup Executor #1/WARN]: Couldn't look up profile properties for **ID**
com.mojang.authlib.exceptions.MinecraftClientHttpException: Status: 429
	at com.mojang.authlib.minecraft.client.MinecraftClient.readInputStream(MinecraftClient.java:100) ~[authlib-6.0.55.jar:?]
	at com.mojang.authlib.minecraft.client.MinecraftClient.get(MinecraftClient.java:57) ~[authlib-6.0.55.jar:?]
	at com.mojang.authlib.yggdrasil.YggdrasilMinecraftSessionService.fetchProfileUncached(YggdrasilMinecraftSessionService.java:201) ~[authlib-6.0.55.jar:?]
	at com.mojang.authlib.yggdrasil.YggdrasilMinecraftSessionService.fetchProfile(YggdrasilMinecraftSessionService.java:171) ~[authlib-6.0.55.jar:?]
	at com.destroystokyo.paper.profile.PaperMinecraftSessionService.fetchProfile(PaperMinecraftSessionService.java:35) ~[paper-1.21.3.jar:1.21.3-82-5a60ffb]
	at org.bukkit.craftbukkit.profile.CraftPlayerProfile.getUpdatedProfile(CraftPlayerProfile.java:180) ~[paper-1.21.3.jar:1.21.3-82-5a60ffb]
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]


[19:19:09] [Profile Lookup Executor #0/WARN]: Couldn't look up profile properties for **ID**
com.mojang.authlib.exceptions.MinecraftClientHttpException: Status: 429
	at com.mojang.authlib.minecraft.client.MinecraftClient.readInputStream(MinecraftClient.java:100) ~[authlib-6.0.55.jar:?]
	at com.mojang.authlib.minecraft.client.MinecraftClient.get(MinecraftClient.java:57) ~[authlib-6.0.55.jar:?]
	at com.mojang.authlib.yggdrasil.YggdrasilMinecraftSessionService.fetchProfileUncached(YggdrasilMinecraftSessionService.java:201) ~[authlib-6.0.55.jar:?]
	at com.mojang.authlib.yggdrasil.YggdrasilMinecraftSessionService.fetchProfile(YggdrasilMinecraftSessionService.java:171) ~[authlib-6.0.55.jar:?]
	at com.destroystokyo.paper.profile.PaperMinecraftSessionService.fetchProfile(PaperMinecraftSessionService.java:35) ~[paper-1.21.3.jar:1.21.3-82-5a60ffb]
	at org.bukkit.craftbukkit.profile.CraftPlayerProfile.getUpdatedProfile(CraftPlayerProfile.java:180) ~[paper-1.21.3.jar:1.21.3-82-5a60ffb]
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]


[19:19:09] [Profile Lookup Executor #1/WARN]: Couldn't look up profile properties for **ID**
com.mojang.authlib.exceptions.MinecraftClientHttpException: Status: 429
	at com.mojang.authlib.minecraft.client.MinecraftClient.readInputStream(MinecraftClient.java:100) ~[authlib-6.0.55.jar:?]
	at com.mojang.authlib.minecraft.client.MinecraftClient.get(MinecraftClient.java:57) ~[authlib-6.0.55.jar:?]
	at com.mojang.authlib.yggdrasil.YggdrasilMinecraftSessionService.fetchProfileUncached(YggdrasilMinecraftSessionService.java:201) ~[authlib-6.0.55.jar:?]
	at com.mojang.authlib.yggdrasil.YggdrasilMinecraftSessionService.fetchProfile(YggdrasilMinecraftSessionService.java:171) ~[authlib-6.0.55.jar:?]
	at com.destroystokyo.paper.profile.PaperMinecraftSessionService.fetchProfile(PaperMinecraftSessionService.java:35) ~[paper-1.21.3.jar:1.21.3-82-5a60ffb]
	at org.bukkit.craftbukkit.profile.CraftPlayerProfile.getUpdatedProfile(CraftPlayerProfile.java:180) ~[paper-1.21.3.jar:1.21.3-82-5a60ffb]
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]`